### PR TITLE
Fix #12

### DIFF
--- a/psite_annotation/annotators/kinase_library.py
+++ b/psite_annotation/annotators/kinase_library.py
@@ -84,15 +84,18 @@ class KinaseLibraryAnnotator:
         if not inplace:
             annotated_df = df.copy()
 
-        site_sequence_plus_minus_5 = (
-            annotated_df["Site sequence context"]
-            .str.slice(start=10, stop=15)
-            .str.upper()
-            + annotated_df["Site sequence context"].str.slice(start=15, stop=16)
-            + annotated_df["Site sequence context"]
-            .str.slice(start=16, stop=21)
-            .str.upper()
-        )
+        def adjust_context_length(sequence_context, desired_length=11):
+            if len(sequence_context) > desired_length:
+                excess = (len(sequence_context) - desired_length) // 2
+                res = sequence_context[excess: excess + desired_length]
+            elif len(sequence_context) < desired_length:
+                padding_length = (desired_length - len(sequence_context)) // 2
+                res = '_' * padding_length + s + '_' * padding_length
+            else:
+                res = sequence_context
+            return res.upper()
+
+        site_sequence_plus_minus_5 = annotated_df["Site sequence context"].apply(adjust_context_length)
 
         annotated_df[
             ["Motif Kinases", "Motif Scores", "Motif Percentiles", "Motif Totals"]

--- a/psite_annotation/annotators/kinase_library.py
+++ b/psite_annotation/annotators/kinase_library.py
@@ -93,7 +93,7 @@ class KinaseLibraryAnnotator:
                 res = '_' * padding_length + sequence_context + '_' * padding_length
             else:
                 res = sequence_context
-            return res.upper()
+            return res[:desired_length//2] + res[desired_length//2].lower() + res[(desired_length//2)+1:].upper()
 
         site_sequence_plus_minus_5 = annotated_df["Site sequence context"].apply(adjust_context_length)
 

--- a/psite_annotation/annotators/kinase_library.py
+++ b/psite_annotation/annotators/kinase_library.py
@@ -90,7 +90,7 @@ class KinaseLibraryAnnotator:
                 res = sequence_context[excess: excess + desired_length]
             elif len(sequence_context) < desired_length:
                 padding_length = (desired_length - len(sequence_context)) // 2
-                res = '_' * padding_length + s + '_' * padding_length
+                res = '_' * padding_length + sequence_context + '_' * padding_length
             else:
                 res = sequence_context
             return res.upper()

--- a/tests/unit_tests/annotators/test_kinase_library.py
+++ b/tests/unit_tests/annotators/test_kinase_library.py
@@ -88,6 +88,120 @@ def expected_output_df() -> pd.DataFrame:
         }
     )
 
+@pytest.fixture
+def input_df_exact_context() -> pd.DataFrame:
+    """Fixture to create an example input dataframe to the annotate() method.
+
+    Returns:
+        pd.DataFrame: Example input dataframe
+
+    """
+    return pd.DataFrame(
+        {
+            "Site sequence context": [
+                "AGGRGsGPGRR",
+                "AGGRGsTYGPG",
+                "GGRGStYGPGR",
+                "GRGSTyGPGRR",
+                "GRGSTyGPGRR",
+            ],
+        }
+    )
+
+
+@pytest.fixture
+def expected_output_df_exact_context() -> pd.DataFrame:
+    """Fixture to create an example ouput dataframe to the annotate() method given the input_df fixture.
+
+    Returns:
+        pd.DataFrame: Output dataframe corresponding to input_df fixture
+
+    """
+    return pd.DataFrame(
+        {
+            "Site sequence context": [
+                "AGGRGsGPGRR",
+                "AGGRGsTYGPG",
+                "GGRGStYGPGR",
+                "GRGSTyGPGRR",
+                "GRGSTyGPGRR",
+            ],
+            "Motif Kinases": [
+                "AAK1;ACVR2A",
+                "ACVR2A",
+                "ACVR2A",
+                "",
+                "",
+            ],
+            "Motif Scores": [
+                "0.515;-2.848",
+                "-1.365",
+                "-1.174",
+                "",
+                "",
+            ],
+            "Motif Percentiles": [
+                "0.946;0.261",
+                "0.638",
+                "0.675",
+                "",
+                "",
+            ],
+            "Motif Totals": [
+                "0.487;-0.745",
+                "-0.871",
+                "-0.792",
+                "",
+                "",
+            ],
+        }
+    )
+
+@pytest.fixture
+def input_df_too_short_context() -> pd.DataFrame:
+    """Fixture to create an example input dataframe to the annotate() method.
+
+    Returns:
+        pd.DataFrame: Example input dataframe
+
+    """
+    return pd.DataFrame(
+        {
+            "Site sequence context": [
+                "GRGsGPG",
+                "GRGsTYG",
+                "RGStYGP",
+                "GSTyGPG",
+                "GSTyGPG",
+            ],
+        }
+    )
+
+
+@pytest.fixture
+def expected_output_df_too_short_context() -> pd.DataFrame:
+    """Fixture to create an example ouput dataframe to the annotate() method given the input_df fixture.
+
+    Returns:
+        pd.DataFrame: Output dataframe corresponding to input_df fixture
+
+    """
+    return pd.DataFrame(
+        {
+            "Site sequence context": [
+                "GRGsGPG",
+                "GRGsTYG",
+                "RGStYGP",
+                "GSTyGPG",
+                "GSTyGPG",
+            ],
+            "Motif Kinases": ["AAK1;ACVR2A", "ACVR2A", "ACVR2A", "", ""],
+            "Motif Scores": ["0.782;-2.476", "-1.619", "-0.67", "", ""],
+            "Motif Percentiles": ["0.952;0.354", "0.581", "0.752", "", ""],
+            "Motif Totals": ["0.745;-0.876", "-0.94", "-0.504", "", ""],
+        }
+    )
+
 
 class TestKinaseLibraryAnnotator:
     """Test the KinaseLibraryAnnotator class."""
@@ -152,6 +266,74 @@ class TestKinaseLibraryAnnotator:
         # Assert that the output dataframe has the expected values
 
         pd.testing.assert_frame_equal(output_df, expected_output_df, check_like=True)
+
+    
+    def test_annotate_exact_context(
+        self,
+        annotator,
+        input_df_exact_context,
+        expected_output_df_exact_context,
+    ):
+        """Test that the annotate method correctly adds the motif annotations to the input dataframe as new column.
+
+        Args:
+            annotator: Annotator object with mock file loaded
+            input_df: Example input dataframe
+            expected_output_df: Expected output dataframe
+
+        """
+        annotator.load_annotations()
+
+        # Annotate the input dataframe
+        output_df = annotator.annotate(input_df_exact_context)
+
+        # Assert that the output dataframe has the expected columns
+        assert set(output_df.columns) == {
+            "Site sequence context",
+            "Motif Kinases",
+            "Motif Scores",
+            "Motif Percentiles",
+            "Motif Totals",
+        }
+
+        print(output_df.to_dict(orient="list"))
+
+        # Assert that the output dataframe has the expected values
+        pd.testing.assert_frame_equal(
+            output_df, expected_output_df_exact_context, check_like=True
+        )
+    def test_annotate_too_short_context(
+        self,
+        annotator,
+        input_df_too_short_context,
+        expected_output_df_too_short_context,
+    ):
+        """Test that the annotate method correctly adds the motif annotations to the input dataframe as new column.
+
+        Args:
+            annotator: Annotator object with mock file loaded
+            input_df: Example input dataframe
+            expected_output_df: Expected output dataframe
+
+        """
+        annotator.load_annotations()
+
+        # Annotate the input dataframe
+        output_df = annotator.annotate(input_df_too_short_context)
+
+        # Assert that the output dataframe has the expected columns
+        assert set(output_df.columns) == {
+            "Site sequence context",
+            "Motif Kinases",
+            "Motif Scores",
+            "Motif Percentiles",
+            "Motif Totals",
+        }
+
+        # Assert that the output dataframe has the expected values
+        pd.testing.assert_frame_equal(
+            output_df, expected_output_df_too_short_context, check_like=True
+        )
 
     def test_annotate_input_df_unchanged(self, annotator, input_df):
         """Test that the annotate method does not alter the input dataframe.


### PR DESCRIPTION
- 'Site sequence context' column is now always adjusted to length 11, independent of its original length
- If original sequence is too short, it's padded with '_'
- It can also deal with sequences of different length in the same df (even though this is unlikely to ever happen)
- ~20x faster than old implementation